### PR TITLE
Fix react hook and type errors on vercel

### DIFF
--- a/components/EB1ACoverLetterSection.tsx
+++ b/components/EB1ACoverLetterSection.tsx
@@ -434,7 +434,7 @@ export function EB1ACoverLetterSection({ language, onShowUploads }: EB1ACoverLet
         } catch (apiError) {
           console.warn('⚠️ API call failed, but file upload was successful. Using local storage only.');
           console.log('📋 API error details:', {
-            error: apiError?.message || 'Unknown error',
+            error: apiError instanceof Error ? apiError.message : 'Unknown error',
             endpoint: '/make-server-54a8f580/user/files'
           });
           


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fix TypeScript error in `EB1ACoverLetterSection.tsx` to allow Vercel build to succeed.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `apiError` variable in the catch block was implicitly typed as an empty object `{}`, leading to a TypeScript compilation error when attempting to access its `message` property. The fix explicitly checks if `apiError` is an instance of `Error` before accessing `message`, resolving the build failure on Vercel.

---
<a href="https://cursor.com/background-agent?bcId=bc-ba487870-2288-4004-9016-3b974f6116e6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ba487870-2288-4004-9016-3b974f6116e6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>